### PR TITLE
Update installation command in README and fix typo in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install kuzukiri
 
 ```bash
 pip install setuptools-rust
-python setup.py install
+python -m pip install .
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     rust_extensions=[RustExtension("kuzukiri.kuzukiri", binding=Binding.PyO3)],
     packages=["kuzukiri"],
     zip_safe=False,
-    classfiers=[
+    classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: Japanese",


### PR DESCRIPTION
Thank you for maintaining this nice repository! In this PR, I have made two changes:

1. Updated the installation command in the "Install from source code" section of the README. According to the current [Python Packaging User Guide](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), `python setup.py install` is deprecated. When I ran `python setup.py install`, I received the following warning:

   ```bash
   $ python setup.py install
   /home/ubuntu/.pyenv/versions/3.11.6/lib/python3.11/site-packages/setuptools/_distutils/dist.py:265: UserWarning: Unknown distribution option: 'classfiers'
   warnings.warn(msg)
   running install
   /home/ubuntu/.pyenv/versions/3.11.6/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
   !!
   ******************************************************************************
   Please avoid running ``setup.py`` directly. Instead, use pypa/build, pypa/installer or other standards-based tools.
   See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
   ******************************************************************************
   !!
   ...

To address this, I have changed the installation command to `python -m pip install .`.


2. Fixed a typo in `setup.py.` The warning message mentioned an unknown distribution option 'classfiers', so I corrected it to 'classifiers'.

